### PR TITLE
GoodJob::Capsule#idle?

### DIFF
--- a/demo/config/boot.rb
+++ b/demo/config/boot.rb
@@ -1,5 +1,5 @@
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __dir__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
-$LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)
+$LOAD_PATH.unshift File.expand_path('../../lib', __dir__)

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -232,12 +232,12 @@ module GoodJob
     # -1 means do not idle out.
     # Since the loop sleeps every 0.1 seconds, this multiples by 10 to get the seconds.
     # @return [Integer, -1]
-    def count_till_idle
+    def shutdown_on_idle
       (
-        options[:count_till_idle] ||
-        rails_config[:count_till_idle] ||
-        env['GOOD_JOB_COUNT_TILL_IDLE']
-      )&.to_i&.*(10) || -1
+        options[:shutdown_on_idle] ||
+        rails_config[:shutdown_on_idle] ||
+        env['GOOD_JOB_SHUTDOWN_ON_IDLE']
+      )&.to_i || -1
     end
 
     # Whether to automatically destroy discarded jobs that have been preserved.
@@ -383,7 +383,7 @@ module GoodJob
     private
 
     def rails_config
-      Rails.application.config.good_job
+      Rails.application.config.good_job || {}
     end
   end
 end

--- a/lib/good_job/multi_scheduler.rb
+++ b/lib/good_job/multi_scheduler.rb
@@ -95,6 +95,7 @@ module GoodJob
         succeeded_executions_count: scheduler_stats.sum { |stats| stats.fetch(:succeeded_executions_count, 0) },
         total_executions_count: scheduler_stats.sum { |stats| stats.fetch(:total_executions_count, 0) },
         execution_at: scheduler_stats.map { |stats| stats.fetch(:execution_at, nil) }.compact.max,
+        active_execution_thread_count: scheduler_stats.map { |stats| stats.fetch(:active_threads, 0) },
         check_queue_at: scheduler_stats.map { |stats| stats.fetch(:check_queue_at, nil) }.compact.max,
       }
     end


### PR DESCRIPTION
Instead of pushing the logic of idle all the way up to the CLI I thought
it would be better in the GoodJob::Capsule class.

I've created a `#idle?` method that does this check based on the last
time a scheduler in the GoodJob::Capsule has run a job.

I ran into an interesting thing that if I check the configuration object
in the initialization of the GoodJob::Capsule it causes a crash because
rails is not initialized yet.  The configuation object can't access the
rails config.

I instead changed it so that in the initialize of the GoodJob::Capsule
the `shutdown_on_idle_enabled` flag is set to false - meaning never
shutdown on idle. Then in `#start` the GoodJob::Capsule checks the
config and sets the flag so that #idle? method will work.
