### PR TITLE
Over wrote something by mistake

### DIFF
--- a/lib/good_job/capsule.rb
+++ b/lib/good_job/capsule.rb
@@ -93,9 +93,9 @@ module GoodJob
       return false unless @shutdown_on_idle_enabled
 
       seconds = @configuration.shutdown_on_idle
-      last_job_executed_at = stats[:last_job_executed_at] || Time.now.utc
+      last_job_executed_at = stats[:last_job_executed_at]
 
-      Time.now.utc - last_job_executed_at >= seconds
+      last_job_executed_at.nil? || (Time.current - last_job_executed_at >= seconds)
     end
 
 

--- a/lib/good_job/cli.rb
+++ b/lib/good_job/cli.rb
@@ -120,7 +120,7 @@ module GoodJob
       end
 
       Kernel.loop do
-        sleep 0.1
+        @stop_good_job_executable.wait(configuration.shutdown_on_idle || SHUTDOWN_EVENT_TIMEOUT)
         break if @stop_good_job_executable.set? || capsule.shutdown? || capsule.idle?
       end
 

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -229,15 +229,14 @@ module GoodJob
     end
 
     # The number of seconds that a good_job process will idle with out runnin a job.
-    # -1 means do not idle out.
-    # Since the loop sleeps every 0.1 seconds, this multiples by 10 to get the seconds.
-    # @return [Integer, -1]
+    # nil means do not idle out.
+    # @return [Integer, nil]
     def shutdown_on_idle
       (
         options[:shutdown_on_idle] ||
         rails_config[:shutdown_on_idle] ||
         env['GOOD_JOB_SHUTDOWN_ON_IDLE']
-      )&.to_i || -1
+      )&.to_i || nil
     end
 
     # Whether to automatically destroy discarded jobs that have been preserved.

--- a/lib/good_job/job_performer/metrics.rb
+++ b/lib/good_job/job_performer/metrics.rb
@@ -32,7 +32,6 @@ module GoodJob # :nodoc:
       # Increments number of dequeue attempts with no executions.
       # @return [Integer]
       def increment_empty_executions
-        @execution_at = Time.current
         @empty_executions.increment
       end
 


### PR DESCRIPTION
I had a stale file open and overwrote the check of the event.  This was after I had pushed up all the code.

This also made me realize that, now one can't set less than a 10 second idle time out.  The CLI will always stay up for at least 10 seconds.  As mentioned in a previous issue, this may cause a support request when someone sets a idle time out of 1 second but the CLI stays up for 10 seconds then shuts down.

In real life I can't imagine that someone would want to have a job server around for less than 10 seconds. Maybe this just needs to be surfaced in the documentation for the command line option.

In any case, I've added code so that the wait will take the shutdown_on_idle as the time out to check the event, or it will take the default of 10 seconds.

Also in my testing I realized that the `executed_at` was being set in every loop because of the `increment_empty_executions`, this meant that the time out would never happen during actual execution.

I've removed the setting of the `executed_at` in this function as technically nothing executed.